### PR TITLE
Fixed variable name in Level5 (pointRight to pointR)

### DIFF
--- a/Level5.html
+++ b/Level5.html
@@ -31,11 +31,11 @@ You unlocked a new tool: Constructing perpendicular lines! Go to <a href="/Level
 <script type="text/javascript">
 {% include testobjects.js %}
 
-checkobject("pointRight",-0.4,0.3);
+checkobject("pointR",-0.4,0.3);
 checkobject("pointPerp",-0.4,0.3);
 checkdirection("segmentPerp",0,0);
 
-if (drawn("pointRight")){
+if (drawn("pointR")){
 	Command('progress = 10');
    }	
 


### PR DESCRIPTION
The .ggb file doesn't have any variable named pointRight (it's named pointR). Renamed the variable in Level5.html to reflect that.

Fixes #345.
Fixes #352.
