### PR TITLE
Fixed variable name in Level25 (pointT to A)

### DIFF
--- a/Level25.html
+++ b/Level25.html
@@ -35,7 +35,7 @@ checkobject("pointL",0,0);
 checkobject("pointLB",0,0);
 checkobject("pointR",0,0);
 checkobject("pointRB",0,0);
-checkobject("pointT",0,0);
+checkobject("A",0,0);
 checkdirection("segmentB");
 checkdirection("segmentLB");
 checkdirection("segmentRB");


### PR DESCRIPTION
The .ggb file doesn't have any variable named pointT (it's named A and referred to as A in segment definitions). Renamed the variable in
Level25.html to reflect that.

Fixes #348.
