### PR TITLE
Show last unlocked level on every page

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,5 +1,5 @@
 <script>
-
+var lastlevelcompleted = null;
 </script>
     {% assign allPages = site.pages | group_by:"cat" %}
         {% for page_cat in allPages %}
@@ -32,17 +32,19 @@
 					{ levelurl +=  encircle2(localStorage.Level{{p.number}}p)+" ";}
 					levelurl +="</li>";
 					document.write(levelurl);
+					lastlevelcompleted = {{p.number}};
 					}			
 					</script>
             {% endfor %}
 			<script>
-			var number = {{page.number}}
-			var next = number + 1;
-			var nextlevel = "Level"+next;			
-			console.log(localStorage.nextlevel);
-					if (localStorage.Level{{page.number}} > 0 && (localStorage[nextlevel] > 0) === false){
-					if ({{page.number}} <25){
-					document.write("<li><a href=\"/"+nextlevel+"\">Level "+next+"</a></li>");}}	
+				if (lastlevelcompleted != null){
+					var next = lastlevelcompleted + 1;
+					var nextlevel = "Level"+next;
+					console.log(localStorage.nextlevel);
+					if (next <= 25){
+						document.write("<li><a href=\"/"+nextlevel+"\">Level "+next+"</a></li>");
+					}
+				}	
 			</script>
         </ul>
         {% endunless %}


### PR DESCRIPTION
Bug:
  The menu only shows the next unlocked level if you are on the last completed level's page.
  e.g. If you have unlocked Level5 and are on page Level1, you will not see Level5 in the menu.

Fix: 
  I modified the menu a little to show the last unlocked level no matter which page you are on.

Tested:
- New session on Tutorial: shows nothing (same as right now)
- Level1 completed, on page Tutorial: Shows up to Level2 (would previously show up to Level1)
- Level1 completed, on page Level1: Shows up to Level2 (same as right now) 
- Level1 completed, on page Level2: Shows up to Level2 (would previously show up to Level1)
- Level1 completed, on page Level20: Shows up to Level2 (would previously show up to Level1)

Fixes #295
