### PR TITLE
Remove "Translate a line" tool from Level7

### DIFF
--- a/Level7.html
+++ b/Level7.html
@@ -19,7 +19,8 @@ You unlocked a new tool: Translating lines ! <b>Note that this new tool won't wo
 </div>
 <script type="text/javascript">
 	{% include parameters480p.js %}
-    parameters.customToolBar = "501 | 5 | 15 | 18 | 10 | 100001 | 100002 | 9 | 4 | 3 "//| 100003 | 53";
+	// Remove the translate tool for this level (100002)
+	parameters.customToolBar = "501 | 5 | 15 | 18 | 10 | 100001 | 9 | 4 | 3 "//| 100003 | 53";
 	parameters.ggbBase64 = "{% base64 ggb/Level7.ggb %}" ;	
 </script>
 


### PR DESCRIPTION
Level 7's goal is to translate a line,
but that tool is available at the beginning of the lesson.

Removed tool 100002 (Translate) from the toolbar for Level7.

Fixes #368 