### PR TITLE
Fix redirect after submitting score from Tutorial

### DIFF
--- a/submitscore.php
+++ b/submitscore.php
@@ -12,6 +12,11 @@ mail($to, $subject, $message.$message2, $headers);
 <script>
 console.log(localStorage.lastLevel);
 
-window.location.href = "/Level"+localStorage.lastLevel+"/";
+if (localStorage.lastLevel > 0) {
+  window.location.href = "/Level"+localStorage.lastLevel+"/";
+}
+else {
+  window.location.href = "/Tutorial/";
+}
 
 </script>


### PR DESCRIPTION
Submitting scores from /Tutorial/ (page.number = 0) redirects back to /Level0/, which doesn't exist.

Fixes #304