### PR TITLE
Don't store scores post-win

### DIFF
--- a/_includes/testobjects.js
+++ b/_includes/testobjects.js
@@ -180,8 +180,12 @@ function drawn(object){
 }
 var setVisible = ggbApplet.setVisible;
 
-function LevelCompleted(condition,mincount){
+var completed = false;
+function LevelCompleted(condition, mincount){
   if (condition) {
+    if (completed)
+      return; 
+
     Command('progress = 100');
     Command('Complete = Text["Level completed !",  '+abspos("0.15","-0.13")+']');
     var count = ggbApplet.getValue("countnumber");
@@ -207,5 +211,7 @@ function LevelCompleted(condition,mincount){
         localStorage.Level{{page.number}} = count;
       }
     }
+
+    completed = true;
   }
 }

--- a/_includes/testobjects.js
+++ b/_includes/testobjects.js
@@ -181,28 +181,31 @@ function drawn(object){
 var setVisible = ggbApplet.setVisible;
 
 function LevelCompleted(condition,mincount){
- if(condition){
- 	Command('progress = 100');
-	Command('Complete = Text["Level completed !",  '+abspos("0.15","-0.13")+']');   
+  if (condition) {
+    Command('progress = 100');
+    Command('Complete = Text["Level completed !",  '+abspos("0.15","-0.13")+']');
     var count = ggbApplet.getValue("countnumber");
-	if (primitives && (count === minlevel{{page.number}}p)){
-	Command('score2 = Text["Perfect ! You have done this challenge in a minimum number of primitive moves!", '+abspos("0.35","-0.602915")+']');}
-	if (!primitives)
-	{ if(count === minlevel{{page.number}}){
-	Command('score2 = Text["Perfect ! You have done this challenge in a minimum number of moves!", '+abspos("0.35","-0.602915")+']');}}
-   //document.getElementById("level").style.display="inline-block";	
-	  $( "#hidden" ).slideDown(1000);	
-   $( "#hiddencomments" ).toggle();	
+    if (primitives && (count === minlevel{{page.number}}p)) {
+        Command('score2 = Text["Perfect ! You have done this challenge in a minimum number of primitive moves!", '+abspos("0.35","-0.602915")+']');
+    }
+    if (!primitives) {
+      if (count === minlevel{{page.number}}) {
+        Command('score2 = Text["Perfect ! You have done this challenge in a minimum number of moves!", '+abspos("0.35","-0.602915")+']');
+      }
+    }
 
+    $( "#hidden" ).slideDown(1000);	
+    $( "#hiddencomments" ).toggle();	
 
-if (primitives){
-if (!(localStorage.Level{{page.number}}p < count)) {localStorage.Level{{page.number}}p = count;}}
-else{
-if(!(localStorage.Level{{page.number}}<count)){localStorage.Level{{page.number}} = count;}}
-
-
-	}
-}   
-
-
-
+    if (primitives) {
+      if (!(localStorage.Level{{page.number}}p < count)) {
+        localStorage.Level{{page.number}}p = count;
+      }
+    }
+    else {
+      if(!(localStorage.Level{{page.number}}<count)) {
+        localStorage.Level{{page.number}} = count;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Once you have already completed a level, we keep processing moves and can overwrite success messages and score counts (for medals).

e.g. Win Level5 in 4 moves with only primitives, set Level5p = 3, accidentaly hit a non-primitive tool on your way out and you'd end up with a Silver medal (4) too.

Also reformatted `LevelCompleted` because it was hard to parse.

Fixes #324 